### PR TITLE
Set the XCode SDK or else you have a bad time on Sierra

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,9 @@
       ],
       'conditions': [
         ['OS=="mac"', {
+          'xcode_settings': {
+            'SDKROOT': 'macosx10.11'
+          },
           'sources': [
             'src/nslog_mac.mm',
           ],


### PR DESCRIPTION
If you don't set the XCode SDK on 10.12, you'll get a version of the headers that include Swift bits that break the build:

```
In file included from ../src/nslog_mac.mm:3:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:10:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/NSArray.h:5:
/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:In file included from ../src/nslog_mac.mm:3:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:10:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/NSArray.h:5:
/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:44:12: error: unknown property attribute 'class'
@property (class, readonly) BOOL supportsSecureCoding;
           ^
44:12: error: unknown property attribute 'class'
@property (class, readonly) BOOL supportsSecureCoding;
           ^
In file included from ../src/nslog_mac.mm:3:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:12:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/NSBundle.h:6:
/System/Library/Frameworks/Foundation.framework/Headers/NSString.h:258:12: error: unknown property attribute 'class'
In file included from ../src/nslog_mac.mm:3:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/Foundation.h:12:
In file included from /System/Library/Frameworks/Foundation.framework/Headers/NSBundle.h:6:
/System/Library/Frameworks/Foundation.framework/Headers/NSString.h:258:12: error: unknown property attribute 'class'
@property (class, readonly) const NSStringEncoding *availableStringEncodings;
           ^
```