### PR TITLE
added node-gyp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "coffee-script": "~1.6.2"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.0.0",
+    "node-gyp": "^3.4.0"
   }
 }


### PR DESCRIPTION
installing nslog (or any package that depends on nslog) fails with yarn. This happens because node-gyp, which is used to build the native code, is not listed as a direct dependency.

Fix: I have added node-gyp to the dependencies in package.json.